### PR TITLE
feat: allow multiple shoutouts at once

### DIFF
--- a/pages/api/profile.js
+++ b/pages/api/profile.js
@@ -1,0 +1,32 @@
+import { getSession } from "next-auth/client";
+import admin from "../../firebase/nodeApp";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    res.status(400).json({ message: "Invalid API method specified" });
+    return;
+  }
+
+  const session = await getSession({ req });
+
+  if (!session) {
+    res.status(401).json({ message: "unauthorized" });
+    return;
+  }
+
+  const db = admin.firestore();
+
+  const profiles = await Promise.all(req.body.names.map(async (name) => {
+    const doc = await db.collection("officer").where("name", "==", name).get()
+    return {
+      ...doc.docs[0].data(),
+      id: doc.docs[0].id
+    };
+  }));
+
+  try {
+    res.status(200).json({ message: "success", profiles: profiles });
+  } catch (e) {
+    res.status(500).json({ message: "failure", error: e });
+  }
+}

--- a/pages/profile/[username].js
+++ b/pages/profile/[username].js
@@ -1,11 +1,11 @@
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import Button from '@mui/material/Button';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
-import CardMedia from '@mui/material/CardMedia';
-import Container from '@mui/material/Container';
-import TextField from '@mui/material/TextField';
-import Typography from '@mui/material/Typography';
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import Button from "@mui/material/Button";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import CardMedia from "@mui/material/CardMedia";
+import Container from "@mui/material/Container";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
 import axios from "axios";
 import { getSession } from "next-auth/client";
 import dynamic from "next/dynamic";
@@ -73,7 +73,11 @@ export default function ProfilePage({ data, session }) {
     <Fragment>
       <Head>
         <title>Leadership: {data.name} | ACM Leadership</title>
-        <meta property="og:title" content={`Leadership: ${data.name} | ACM Leadership`} key="title" />
+        <meta
+          property="og:title"
+          content={`Leadership: ${data.name} | ACM Leadership`}
+          key="title"
+        />
       </Head>
       <Container maxWidth="lg">
         <NavBar session={session} />
@@ -155,13 +159,19 @@ export default function ProfilePage({ data, session }) {
                   maxRows={12}
                   onChange={onChange}
                   variant="filled"
-                  style={{ minWidth: "360px", marginTop: 12 }}
+                  style={{ minWidth: "360px", marginTop: 12, marginBottom: 12 }}
                 />
                 <Typography variant="inherit" component="div">
                   <Button onClick={sendAccolade} size="small">
                     Send Accolade
                   </Button>
                 </Typography>
+                <hr style={{ maxWidth: 200 }} />
+                <Link href={`/shoutout`} passHref>
+                  <Button size="small">
+                    Shoutout {data.name.split(" ")[0]} and others!
+                  </Button>
+                </Link>
               </CardContent>
             </Card>
           ) : (

--- a/pages/shoutout.js
+++ b/pages/shoutout.js
@@ -1,0 +1,179 @@
+import Autocomplete from "@mui/material/Autocomplete";
+import Button from "@mui/material/Button";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import Container from "@mui/material/Container";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import axios from "axios";
+import { getSession } from "next-auth/client";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { Fragment, useEffect, useState } from "react";
+import NavBar from "../components/NavBar";
+import { getOfficers } from "../fetchData/getOfficers";
+
+export default function ProfilePage({ officerList, roleList, session }) {
+  if (!session) {
+    return <AccessDenied />;
+  }
+
+  const [accolade, setAccolade] = useState(
+    "You're the best! Thanks for being awesome!"
+  );
+
+  // contains the list of all names only that is used to populate the search bar auto-fill
+  const [officerNames, setOfficerNames] = useState([]);
+
+  // selected names to send a shoutout to
+  const [names, setNames] = useState([]);
+
+  // Sorts the array in ascending order by first name
+  useEffect(() => {
+    setOfficerNames(officerList.map(({ id, name }, index) => name));
+  }, []);
+
+  const router = useRouter();
+
+  const onChange = (event) => {
+    setAccolade(event.target.value);
+  };
+
+  const sendAccolade = async () => {
+    // fetch profiles
+    const response = await axios.post("/api/profile", { names: names }, {});
+
+    // generate payloads for each shoutout
+    const payloads = response.data.profiles.map((profile, index) => {
+      return {
+        sender_name: session.user.name,
+        sender_email: session.user.email,
+        to: profile.acm_email,
+        receiver_name: profile.name,
+        accolade: accolade,
+        user_id: profile.id,
+        collection: "officer",
+      };
+    });
+
+    // send all shoutouts in parallel
+    await Promise.all(
+      payloads.map(async (payload, index) => {
+        return Promise.all([
+          axios.post(router.basePath + "/api/email", payload, {}),
+          axios.post(router.basePath + "/api/slack", payload, {}),
+          axios.post(router.basePath + "/api/accolade", payload, {}),
+        ]);
+      })
+    );
+    
+    // reload page
+    router.reload();
+  };
+
+  const selectedOfficers = names.map((name, index) => {
+    return (
+      <div key={index}>
+        <Typography variant="inherit">{name}</Typography>
+        <Button
+          size="small"
+          onClick={() => {
+            setNames(names.filter((item) => item !== name));
+          }}
+        >
+          Remove
+        </Button>
+      </div>
+    );
+  });
+
+  return (
+    <Fragment>
+      <Head>
+        <title>Shoutout | ACM Leadership</title>
+        <meta
+          property="og:title"
+          content="Shoutout | ACM Leadership"
+          key="title"
+        />
+      </Head>
+      <Container maxWidth="lg">
+        <NavBar session={session} />
+        <div style={{ paddingTop: 90 }}>
+          <Typography style={{ margin: 12 }} variant="h3" component="div">
+            Shoutout!
+          </Typography>
+          <Typography variant="inherit" component="div">
+            Send a shoutout to one or more people at once!
+          </Typography>
+          <Card
+            raised
+            style={{
+              margin: 12,
+              minWidth: 300,
+              maxWidth: 400,
+              marginLeft: "auto",
+              marginRight: "auto",
+            }}
+          >
+            <CardContent>
+              <Typography variant="h5" component="div">
+                Give an accolade to:
+              </Typography>
+              <hr style={{ maxWidth: 200 }} />
+              {selectedOfficers}
+              <Autocomplete
+                disablePortal
+                style={{
+                  marginLeft: 90,
+                  marginRight: 90,
+                  marginTop: 24,
+                  marginBottom: 24,
+                }}
+                id="combo-box"
+                options={officerNames}
+                renderInput={(params) => (
+                  <TextField {...params} label="Search" />
+                )}
+                onChange={(event, newValue) => {
+                  if (newValue === "" || newValue === null || newValue === undefined) {
+                    return;
+                  }
+                  setNames([...names, newValue]);
+                }}
+              />
+              <hr style={{ maxWidth: 200 }} />
+              <TextField
+                multiline
+                minRows={8}
+                maxRows={12}
+                onChange={onChange}
+                variant="filled"
+                style={{ minWidth: "360px", marginTop: 12 }}
+              />
+              <Typography variant="inherit" component="div">
+                <Button onClick={sendAccolade} size="small">
+                  Send Accolade
+                </Button>
+              </Typography>
+            </CardContent>
+          </Card>
+        </div>
+      </Container>
+    </Fragment>
+  );
+}
+
+export async function getServerSideProps(context) {
+  const { officers, role_list } = await getOfficers(context.query.q);
+  const session = await getSession(context);
+
+  if (!officers || !role_list) {
+    return {
+      notFound: true,
+    };
+  }
+  return {
+    props: { officerList: officers, roleList: role_list, session }, // will be passed to the page component as props
+  };
+}


### PR DESCRIPTION
Changes
 - New endpoint at `/api/profile` to fetch profiles for multiple officers at once
 - New page at `/shoutout` which allows for sending multiple shoutouts
 - New button at `/profile/[username].js` which redirects to `/shoutout`