### PR TITLE
fix: home page text alignment

### DIFF
--- a/components/HomeGrid.tsx
+++ b/components/HomeGrid.tsx
@@ -15,13 +15,13 @@ interface PageProps {
 
 export default function HomeGrid({ header, text, path }: PageProps) {
   return (
-    <Grid item xs={12} md={6} lg={4} style={{margin: "auto"}}>
+    <Grid item xs={12} md={6} lg={4} style={{margin: "auto", width: 300}}>
       <Card raised>
         <CardContent>
           <Typography variant="h5" component="div" style={{ marginBottom: 24 }}>
             {header}
           </Typography>
-          <Typography variant="body2" component="div" style={{ width: 300 }}>
+          <Typography variant="body2" component="div">
             {text}
           </Typography>
         </CardContent>


### PR DESCRIPTION
I haven't worked with Material UI before so I'm not sure if this follows best practices but it was a simple change and doesnt seem to mess anything else up.

fixes #51 